### PR TITLE
Support whitespaces for NumericCode

### DIFF
--- a/lib/MooseX/Types/Common/String.pm
+++ b/lib/MooseX/Types/Common/String.pm
@@ -54,7 +54,7 @@ subtype NumericCode,
 
 coerce NumericCode,
   from NonEmptySimpleStr,
-  via { my $code = $_; $code =~ s/[[:punct:]]//g; return $code };
+  via { my $code = $_; $code =~ s/[[:punct:][:space:]]//g; return $code };
 
 subtype Password,
   as NonEmptySimpleStr,
@@ -218,7 +218,7 @@ A coercion exists via C<uc> from C<NonEmptyStr>
 A C<Str> with no new-line characters that consists of only Numeric characters.
 Examples include, Social Security Numbers, Personal Identification Numbers, Postal Codes, HTTP Status
 Codes, etc. Supports attempting to coerce from a string that has punctuation
-in it ( e.g credit card number 4111-1111-1111-1111 ).
+or whitespaces in it ( e.g credit card number 4111-1111-1111-1111 ).
 
 =back
 

--- a/t/04-coerce.t
+++ b/t/04-coerce.t
@@ -18,6 +18,7 @@ is(to_LowerCaseSimpleStr('BAR'), 'bar', 'lowercase str' );
 is(to_UpperCaseStr('foo'), 'FOO', 'uppercase str' );
 is(to_LowerCaseStr('BAR'), 'bar', 'lowercase str' );
 
-is(to_NumericCode('4111-1111 1111-1111'), '4111111111111111', 'numeric code' );
+is(to_NumericCode('4111-1111-1111-1111'), '4111111111111111', 'numeric code' );
+is(to_NumericCode('+1 (800) 555-01-23'), '18005550123', 'numeric code' );
 
 done_testing;

--- a/t/04-coerce.t
+++ b/t/04-coerce.t
@@ -18,6 +18,6 @@ is(to_LowerCaseSimpleStr('BAR'), 'bar', 'lowercase str' );
 is(to_UpperCaseStr('foo'), 'FOO', 'uppercase str' );
 is(to_LowerCaseStr('BAR'), 'bar', 'lowercase str' );
 
-is(to_NumericCode('4111-1111-1111-1111'), '4111111111111111', 'numeric code' );
+is(to_NumericCode('4111-1111 1111-1111'), '4111111111111111', 'numeric code' );
 
 done_testing;


### PR DESCRIPTION
Sometime the numeric codes consists white spaces instead of punctuation (e.g credit card number 4111 1111 1111 1111).