### PR TITLE
Inline NumericCode

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for MooseX-Types-Common
 
 {{$NEXT}}
 
+  - provide inlined version of NumericCode
+
 0.001013  2015-03-28 22:16:00Z
   - better fix for fully-qualified type names, made to MooseX::Types directly
   - whitespace is now permitted in the NumericCode type (Denis Ibaev)

--- a/lib/MooseX/Types/Common/String.pm
+++ b/lib/MooseX/Types/Common/String.pm
@@ -52,7 +52,14 @@ subtype NumericCode,
   message {
     'Must be a non-empty single line of no more than 255 chars that consists '
         . 'of numeric characters only'
-  };
+  },
+    ( $Moose::VERSION >= 2.0200
+        ? inline_as {
+            $_[0]->parent()->_inline_check( $_[1] ) . ' && '
+                . qq{ $_[1] =~ m/^[0-9]+\$/ };
+        }
+        : ()
+    );
 
 coerce NumericCode,
   from NonEmptySimpleStr,


### PR DESCRIPTION
I noticed this was missing while profiling some code.